### PR TITLE
fixes typo and annotation field removal

### DIFF
--- a/app/models/concerns/foreman_vmwareannotations/vmware_extensions.rb
+++ b/app/models/concerns/foreman_vmwareannotations/vmware_extensions.rb
@@ -3,7 +3,7 @@ module ForemanVmwareannotations
     extend ActiveSupport::Concern
 
     def host_compute_attrs(host)
-      super(host).merge(:annotations => host.comment)
+      super(host).merge(:annotation => host.comment)
     end
   end
 end

--- a/app/overrides/remove_annotations_field.rb
+++ b/app/overrides/remove_annotations_field.rb
@@ -1,5 +1,5 @@
-Deface::Override.new(
-  :name => 'remove_annotations_field',
-  :virtual_path => 'app/views/compute_resources_vms/form/vmware/_base',
-  :remove => "#host_compute_attributes_annotation"
+Deface::Override.new(:virtual_path => "compute_resources_vms/form/vmware/_base",
+  :name => "remove_annotations_field",
+  :remove => "erb[loud]:contains('annotation')",
+  :original => 'cadd97e0a38a36d4464160a972191df90aa6610f'
 )


### PR DESCRIPTION
@timogoebel this should be it, I think
although it doesn't test successfully in my dev environment :/ then again, my dev environment might not be 100% representative... can you check ?
when i manually removed the field in foreman core during the construction day, all worked fine